### PR TITLE
Deploy dist to gh pages

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "scripts": {
     "start": "parcel serve src/pages/index.html src/data/* --open",
-    "build": "parcel build --no-minify src/pages/index.html src/data/* --public-url ./",
+    "build": "rm -rf dist && parcel build --no-minify src/pages/index.html src/data/* --public-url ./",
     "predeploy": "yarn build",
     "deploy": "gh-pages -d dist",
     "copy": "source .env && rsync -qazP $DEPLOY_FILES $DEPLOY_TARGET"

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   "author": "Sam Rosen",
   "license": "MIT",
   "scripts": {
-    "start": "parcel serve src/pages/index.html --open",
-    "build": "parcel build src/pages/index.html --public-url ./",
+    "start": "parcel serve src/pages/index.html src/data/* --open",
+    "build": "parcel build --no-minify src/pages/index.html src/data/* --public-url ./",
     "predeploy": "yarn build",
     "deploy": "gh-pages -d dist",
     "copy": "source .env && rsync -qazP $DEPLOY_FILES $DEPLOY_TARGET"

--- a/src/scripts/handler.js
+++ b/src/scripts/handler.js
@@ -55,7 +55,7 @@ class Handler {
   }
 
   loadCsv(path) {
-    axios.get(require(path)).then((response) => {
+    axios.get(path).then((response) => {
       this.buildDataProcessor(response.data);
 
       this.clearDrawerBuffers();

--- a/src/scripts/toolbar.js
+++ b/src/scripts/toolbar.js
@@ -59,11 +59,11 @@ class Toolbar {
   determineDatasetPath(dataset) {
     switch (dataset) {
       case "tsne":
-        return "../data/tsne.csv";
+        return "data/tsne.csv";
       case "tsne-10":
-        return "../data/tsne_tenth.csv";
+        return "data/tsne_tenth.csv";
       case "tsne-100":
-        return "../data/tsne_hundreth.csv";
+        return "data/tsne_hundreth.csv";
       default:
         console.error(`Did not recognize dataset: ${dataset}`);
     }


### PR DESCRIPTION
Well as the description says `yarn deploy` to gh-pages works. 

Also seems like this is a [known issue with parcel v1](https://stackoverflow.com/questions/67087634/parcel-js-tree-render-is-not-a-function) but not with parcel v2, build fails without `--no-minify`

```
⋊> ~/P/p/webgl-point-interactivity-demo on main ◦ npm run build                            (base) 23:34:30

> webgl-point-interactivity-demo@1.0.0 build
> parcel build src/pages/index.html --public-url ./

🚨  /Users/kancherj/Projects/public/webgl-point-interactivity-demo/src/pages/index.html: tree.render is not a function
    at /Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/htmlnano/lib/modules/minifySvg.js:19:23
    at /Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:91:45
    at traverse (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:105:26)
    at traverse (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:111:5)
    at traverse (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:105:17)
    at traverse (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:111:5)
    at traverse (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:105:17)
    at traverse (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:111:5)
    at traverse (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:105:17)
    at Array.match (/Users/kancherj/Projects/public/webgl-point-interactivity-demo/node_modules/posthtml/lib/api.js:90:7)
```